### PR TITLE
Fix #420

### DIFF
--- a/SystemLocalized/ctt/Dig.ctt
+++ b/SystemLocalized/ctt/Dig.ctt
@@ -75,3 +75,7 @@ Hint="Prem els botons vermells a la paret empenyent-los."
 Message="L'estat de font d'alimentació dos de camp de força és actiu."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Prem els botons vermells a la paret empenyent-los."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Heu recollit 80 Fragments de Taridi"

--- a/SystemLocalized/det/Dig.det
+++ b/SystemLocalized/det/Dig.det
@@ -75,3 +75,7 @@ Hint="Drücke auf die roten Knöpfe an der Wand, indem du gegen sie stößt."
 Message="Kraftfeld-Energieversorgung Zwei, Status ist aktiv."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Drücke auf die roten Knöpfe an der Wand, indem du gegen sie stößt."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium shards"
+PickupMessage="80 Tarydiumsplitter erhalten"

--- a/SystemLocalized/est/Dig.est
+++ b/SystemLocalized/est/Dig.est
@@ -75,3 +75,7 @@ Hint="Pulsa los botones rojos del muro tocándolos."
 Message="Fuente de energía dos del Campo de Fuerza activa."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Pulsa los botones rojos del muro tocándolos."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium shards"
+PickupMessage="Has recogido 80 Fragmentos de Taridio"

--- a/SystemLocalized/frt/Dig.frt
+++ b/SystemLocalized/frt/Dig.frt
@@ -75,3 +75,7 @@ Hint="Appuyez sur les boutons rouges au mur en les touchant."
 Message="La source d'énergie 2 du champ de force est active."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Appuyez sur les boutons rouges au mur en les touchant."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium shards"
+PickupMessage="Vous avez ramassé 80 Éclats de Tarydium"

--- a/SystemLocalized/int/Dig.int
+++ b/SystemLocalized/int/Dig.int
@@ -52,3 +52,6 @@ Hint="Press the red buttons on the wall by bumping into them."
 [TranslatorEvent7]
 Message="Force Field power source two status is active."
 Hint="Press the red buttons on the wall by bumping into them."
+
+[StingerAmmo17]
+PickupMessage="You picked up 80 Tarydium Shards"

--- a/SystemLocalized/itt/Dig.itt
+++ b/SystemLocalized/itt/Dig.itt
@@ -75,3 +75,7 @@ Hint="Premi i pulsanti rossi sul muro andandoci contro."
 Message="Lo stato della seconda fonte d'energia del Campo di Forza è "attivo"."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Premi i pulsanti rossi sul muro andandoci contro."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Hai raccolto 80 schegge di Tarydium"

--- a/SystemLocalized/nlt/Dig.nlt
+++ b/SystemLocalized/nlt/Dig.nlt
@@ -75,3 +75,7 @@ Hint="Druk op de rode knoppen aan de muur door er tegenaan te botsen."
 Message="KrachtVeld stroombron twee status is actief."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Druk op de rode knoppen aan de muur door er tegenaan te botsen."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Je hebt 80 Tarydium-scherven"

--- a/SystemLocalized/plt/Dig.plt
+++ b/SystemLocalized/plt/Dig.plt
@@ -75,3 +75,7 @@ Hint="Podejdź do czerwonych przycisków przy ścianie, aby je włączyć."
 Message="Drugie źródło zasilania pola siłowego jest aktywne."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Podejdź do czerwonych przycisków przy ścianie, aby je włączyć."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Podnosisz 80 Odłamków Tarydu"

--- a/SystemLocalized/ptt/Dig.ptt
+++ b/SystemLocalized/ptt/Dig.ptt
@@ -75,3 +75,7 @@ Hint="Aperte os botões vermelhos na parede batendo neles."
 Message="O estado da fonte de energia dois do Campo de Força é ativo."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Aperte os botões vermelhos na parede batendo neles."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Você pegou 80 Fragmentos de Tarídio"

--- a/SystemLocalized/rut/Dig.rut
+++ b/SystemLocalized/rut/Dig.rut
@@ -75,3 +75,7 @@ Hint="Нажмите на красные кнопки на стене навал
 Message="Статус второго источника питания силового поля - активен."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Нажмите на красные кнопки на стене навалившись на них."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Вы взяли 80 кристаллов таридия"


### PR DESCRIPTION
There's a Stinger Ammo pickup that gives 80 instead of the regular 40 shards. This commit fixes this as reported in #420.